### PR TITLE
Bugfix 🐛 Use one client per goroutine during `func EncryptFilesInDirNPE`

### DIFF
--- a/.github/workflows/build-golang-macos.yaml
+++ b/.github/workflows/build-golang-macos.yaml
@@ -47,4 +47,4 @@ jobs:
 
       # - uses: ./.github/workflows/platform-integration-test.yaml
       #   with:
-      #     wheel: dist/otdf_python-0.2.5-py3-none-any.whl
+      #     wheel: dist/otdf_python-0.2.6-py3-none-any.whl

--- a/.github/workflows/build-golang-ubuntu.yaml
+++ b/.github/workflows/build-golang-ubuntu.yaml
@@ -43,12 +43,12 @@ jobs:
 
       - uses: actions/cache/restore@v4
         with:
-          path: dist/otdf_python-0.2.5-py3-none-any.whl
+          path: dist/otdf_python-0.2.6-py3-none-any.whl
           key: ${{ runner.os }}${{ matrix.python3_version }}-data-${{ github.sha }}
 
       - uses: actions/cache/save@v4
         with:
-          path: dist/otdf_python-0.2.5-py3-none-any.whl
+          path: dist/otdf_python-0.2.6-py3-none-any.whl
           key: ${{ runner.os }}${{ matrix.python3_version }}-data-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}${{ matrix.python3_version }}-data-
@@ -61,5 +61,5 @@ jobs:
     needs: build
     uses: ./.github/workflows/platform-integration-test.yaml
     with:
-      wheel: dist/otdf_python-0.2.5-py3-none-any.whl
+      wheel: dist/otdf_python-0.2.6-py3-none-any.whl
       python_version: ${{ matrix.python3_version }}

--- a/.github/workflows/platform-integration-test.yaml
+++ b/.github/workflows/platform-integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/cache/restore@v4
         with:
-          path: dist/otdf_python-0.2.5-py3-none-any.whl
+          path: dist/otdf_python-0.2.6-py3-none-any.whl
           key: ${{ runner.os }}${{ inputs.python_version }}-data-${{ github.sha }}
 
       - name: Prove that the input file is available

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Install from the [Python Package Index (PyPI)](https://pypi.org):
 pip install otdf_python
 
 # Install a pinned version
-pip install otdf-python==0.2.5
+pip install otdf-python==0.2.6
 
 # Install a pinned version, from test.pypi.org
-pip install -i https://test.pypi.org/simple/ otdf-python==0.2.5
+pip install -i https://test.pypi.org/simple/ otdf-python==0.2.6
 ```
 
 ## Usage

--- a/build-scripts/ci-build.sh
+++ b/build-scripts/ci-build.sh
@@ -72,4 +72,4 @@ echo "✨✨✨ Build wheel"
 poetry run python3 setup.py bdist_wheel
 
 echo "✨✨✨ Install wheel"
-pip install dist/otdf_python-0.2.5-py3-none-any.whl
+pip install dist/otdf_python-0.2.6-py3-none-any.whl

--- a/build-scripts/make_and_validate_script.sh
+++ b/build-scripts/make_and_validate_script.sh
@@ -47,7 +47,7 @@ python3 -m pip install --upgrade setuptools wheel
 python3 setup.py bdist_wheel
 
 # Prove that the wheel can be installed
-pip install dist/otdf_python-0.2.5-py3-none-any.whl
+pip install dist/otdf_python-0.2.6-py3-none-any.whl
 
 if [[ "$SKIP_TESTS" == "-s" || "$SKIP_TESTS" == "--skip-tests" ]]; then
     echo "Build is complete, skipping tests."

--- a/build-scripts/uv_make_and_validate_script.sh
+++ b/build-scripts/uv_make_and_validate_script.sh
@@ -70,7 +70,7 @@ loud_print "Installing wheel"
 uv venv .venv-wheel --python 3.12 "$PY_TYPE"
 source "${BUILD_ROOT}/.venv-wheel/bin/activate"
 pip install pybindgen
-pip install dist/otdf_python-0.2.5-py3-none-any.whl
+pip install dist/otdf_python-0.2.6-py3-none-any.whl
 
 if [[ "$SKIP_TESTS" == "-s" || "$SKIP_TESTS" == "--skip-tests" ]]; then
     echo "Build is complete, skipping tests."

--- a/main.go
+++ b/main.go
@@ -364,10 +364,6 @@ in the same directory as the input files, with a .tdf extension added to the fil
 */
 func EncryptFilesInDirNPE(dirPath string, config OpentdfConfig, dataAttributes []string) ([]string, error) {
 	authScopes := []string{"email"}
-	sdkClient, err := newSdkClient(config, authScopes)
-	if err != nil {
-		return nil, err
-	}
 
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -383,6 +379,11 @@ func EncryptFilesInDirNPE(dirPath string, config OpentdfConfig, dataAttributes [
 			wg.Add(1)
 			go func(file os.DirEntry) {
 				defer wg.Done()
+				sdkClient, err := newSdkClient(config, authScopes)
+				if err != nil {
+					fmt.Printf("failed to create SDK client: %v\n", err)
+					return
+				}
 				inputFilePath := path.Join(dirPath, file.Name())
 				outputFilePath := inputFilePath + ".tdf"
 				got, err := encryptFileWithClient(inputFilePath, outputFilePath, sdkClient, config, dataAttributes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "otdf-python"
 # Should match 'setup.py' version number (used for gopy/pybindgen)
-version = "0.2.5"
+version = "0.2.6"
 description = "Unofficial OpenTDF SDK for Python."
 authors = [
     {name="b-long", email="b-long@users.noreply.github.com"}
@@ -19,7 +19,7 @@ pybindgen = "^0.22.1"
 
 [tool.poetry]
 package-mode = false
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     url="https://github.com/b-long/opentdf-python-sdk",
     package_data={"otdf_python": ["*.so"]},
     # Should match 'pyproject.toml' version number
-    version="0.2.5",
+    version="0.2.6",
     author_email="b-long@users.noreply.github.com",
     include_package_data=True,
 )

--- a/setup_ci.py
+++ b/setup_ci.py
@@ -81,7 +81,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="otdf_python",
-    version="0.2.5",
+    version="0.2.6",
     author="b-long",
     description="Unofficial OpenTDF SDK for Python.",
     long_description_content_type="text/markdown",

--- a/uv.lock
+++ b/uv.lock
@@ -3,5 +3,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "otdf-python"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }


### PR DESCRIPTION
Avoids `fatal error: concurrent map writes` in version 0.2.5